### PR TITLE
remove backtick symbol from table names

### DIFF
--- a/query_string.go
+++ b/query_string.go
@@ -86,6 +86,7 @@ func (p QueryString) tableNamesByFROM() (names []string) {
 func cleanName(name string) string {
 	name = strings.Fields(name)[0]
 	name = strings.TrimSpace(name)
+	name = strings.Trim(name,"`")
 	lastRune := name[len(name)-1]
 	if lastRune == ';' {
 		name = name[:len(name)-1]

--- a/query_string_test.go
+++ b/query_string_test.go
@@ -79,6 +79,10 @@ func TestQueryString_TableNames(t *testing.T) {
 		tableNames []string
 	}{
 		{
+			"SELECT * FROM `table1`, `table2`, `table3` WHERE true;",
+			[]string{"table1", "table2", "table3"},
+		},
+		{
 			"SELECT * FROM table1, table2, table3 WHERE true;",
 			[]string{"table1", "table2", "table3"},
 		},


### PR DESCRIPTION
table names should not contain the back-tick `   symbol 